### PR TITLE
Revert "Fix choice text for empty page object"

### DIFF
--- a/djangocms_url_manager/views.py
+++ b/djangocms_url_manager/views.py
@@ -17,7 +17,7 @@ class ContentTypeObjectSelect2View(ListView):
                     'text': str(obj),
                     'id': obj.pk,
                 }
-                for obj in context['object_list'] if str(obj)
+                for obj in context['object_list']
             ],
             'more': context['page_obj'].has_next(),
         }

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from django.contrib.contenttypes.models import ContentType
 
 from cms.api import create_page
@@ -46,16 +44,6 @@ class UrlManagerSelect2ViewsTestCase(BaseUrlTestCase):
             [p['id'] for p in response.json()['results']],
             [self.poll_content.pk, self.poll_content2.pk],
         )
-
-    def test_return_empty_choices_when_page_do_not_have_title_in_select2_view(self):
-        with self.login_user_context(self.superuser):
-            with mock.patch('cms.models.Page.__str__', lambda _: ''):
-                response = self.client.get(
-                    self.select2_endpoint,
-                    data={'content_id': self.page_contenttype_id},
-                )
-        self.assertEqual(response.status_code, 200)
-        self.assertFalse(response.json()['results'])
 
     def test_raise_error_when_return_unregistered_user_model_in_select2_view(self):
         with self.login_user_context(self.superuser):


### PR DESCRIPTION
Reverts divio/djangocms-url-manager#10

After discussions, we will provide str for unpublished/not published pages, and for other objects.