### PR TITLE
Updated js in forms for 2.2 upgrade

### DIFF
--- a/djangocms_url_manager/forms.py
+++ b/djangocms_url_manager/forms.py
@@ -14,7 +14,7 @@ from .utils import supported_models
 class Select2Mixin:
     class Media:
         css = {"all": ("cms/js/select2/select2.css",)}
-        js = ("cms/js/select2/select2.js", "djangocms_url_manager/js/create_url.js")
+        js = ("admin/js/jquery.init.js", "cms/js/select2/select2.js", "djangocms_url_manager/js/create_url.js")
 
 
 class SiteSelectWidget(Select2Mixin, forms.Select):


### PR DESCRIPTION
This fixes the broken js in the url manager select2 widget

https://docs.djangoproject.com/en/3.0/releases/2.2/#merging-of-form-media-assets