### PR TITLE
Fix broken test suite due to dependancy updates

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,5 @@ djangocms_helper
 pyflakes>=2.1.1
 flake8
 isort
+django-classy-tags<2.0.0
+django-sekizai<2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ skip_missing_interpreters=True
 setenv =
     versioning: ENABLE_VERSIONING = 1
 deps =
-    -r{toxinidir}/tests/requirements.txt
+    -r {toxinidir}/tests/requirements.txt
 
     dj111: Django>=1.11,<2.0
     dj20: Django>=2.0,<2.1


### PR DESCRIPTION
Pin classytags and sekizai to pre 2.0.0 versions for Dj 1.11 to 2.1 support in tests